### PR TITLE
Run update on dynamic Jenkins node

### DIFF
--- a/Jenkinsfile.update-xpub
+++ b/Jenkinsfile.update-xpub
@@ -2,12 +2,9 @@ elifeUpdatePipeline(
     { commit ->
         // sh 'env' 
         // DOCKER_TRIGGER_REPO_NAME=xpub
-        elifeOnNode(
-            {
-                commit = dockerReadLabel('xpub/xpub-elife:latest', 'COMMIT_SHA')
-            },
-            'containers--medium'
-        )
+        node('containers-jenkins-plugin') {
+            commit = dockerReadLabel('xpub/xpub-elife:latest', 'COMMIT_SHA')
+        }
         sh "sed -i -e 's/XPUB_VERSION=.*/XPUB_VERSION=${commit}/' .env"
         sh "git add .env"
     },


### PR DESCRIPTION
The update process download some Docker images and reads their labels to produce a PR. This is executed on a specialized Jenkins node, which is being transitioned to a new implementation where the node is created dynamically be Jenkins.

Reference nodes (if that's visible to you): https://alfred.elifesciences.org/computer/