### PR TITLE
Introduce docker-compose.formula.yml to mount AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ docker-compose up
 
 Visit the web interface at [http://localhost:3000].
 
+Formula setup
+=============
+
+When used as part of `elife-xpub-formula`, an additional `docker-compose.formula.yml` should be used as configuration for all commands:
+
+```
+docker-compose -f docker-compose.yml -f docker-compose.formula.yml up
+```
+
 Build
 =====
 

--- a/docker-compose.formula.yml
+++ b/docker-compose.formula.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+services:
+    app:
+        volumes:
+            - /home/elife/.aws/credentials:/root/.aws/credentials


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/622

Settings that are specific to this repository usage in a formula can be addressed in this separate file. Hence, we keep the capability to check out this repository and run `docker-compose up` (and similar) anywhere, for reproducing part of the environment without a AWS EC2 instance or a Vagrant VM.