### PR TITLE
Update path of AWS credentials

### DIFF
--- a/docker-compose.formula.yml
+++ b/docker-compose.formula.yml
@@ -3,4 +3,4 @@ version: '3'
 services:
     app:
         volumes:
-            - /home/elife/.aws/credentials:/root/.aws/credentials
+            - /home/elife/.aws/credentials:/home/xpub/.aws/credentials


### PR DESCRIPTION
`elife-xpub` is based off of an image where the $HOME directory is `/home/xpub`. This change places the `~/.aws/credentials` file in the correct location so the [AWS SDK can pick it up](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-shared.html)