### PR TITLE
Remove default ORCID config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,6 @@ services:
                 "scienceBeam":{
                     "url":"http://sciencebeam:8075/api/convert"
                 },
-                "auth-orcid": {
-                    "sandbox": ${ORCID_SANDBOX}
-                },
                 "meca": {
                     "s3": {
                         "params": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
             - postgres
         environment:
             NODE_ENV: production
+            NODE_CONFIG_ENV:
             NODE_CONFIG: '{
                 "scienceBeam":{
                     "url":"http://sciencebeam:8075/api/convert"


### PR DESCRIPTION
Related to https://github.com/elifesciences/elife-xpub/pull/667

Sandbox mode is being disabled in production in the above PR.

`NODE_CONFIG` is overriding all of the config we set within the application as it's passed along as a [command-line override](https://github.com/lorenwest/node-config/wiki/Command-Line-Overrides).  This stopped us from disabling sandbox mode in production and keeping it enabled in demo.

We're removing it so we can load [environment specific config files](https://github.com/lorenwest/node-config/wiki/Configuration-Files) based on the value of `NODE_CONFIG_ENV`