### PR TITLE
Add Docker restart policy for application container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
             "
         ports:
             - 3000:3000
+        restart: always
         depends_on:
             - postgres
         environment:


### PR DESCRIPTION
See https://docs.docker.com/config/containers/start-containers-automatically/#use-a-restart-policy where `always` seems the only applicable one for the container to survive server restarts (frequent in testing environments)