### PR TITLE
Restart postgres container on boot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
             POSTGRES_DB: ${PGDATABASE}
         volumes:
             - postgres-volume:/var/lib/postgresql/data
+        restart: always
 
     # useful to run `docker wait ...` to wait for the application outside from the host
     bootstrap:


### PR DESCRIPTION
I thought `depends_on` from `app` would take care of this, but it seems not.