### PR TITLE
Run end2end test(s)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,11 @@ elifePipeline {
                     stackname: 'elife-xpub--end2end',
                     revision: commit,
                     folder: '/srv/elife-xpub',
-                    concurrency: 'blue-green'
+                    concurrency: 'blue-green',
+                    rollbackStep: {
+                        builderDeployRevision 'elife-xpub--end2end', 'approved'
+                        builderSmokeTests 'elife-xpub--end2end', '/srv/elife-xpub'
+                    }
                 ],
                 marker: 'xpub'
             )
@@ -35,6 +39,11 @@ elifePipeline {
 
         stage 'Approval', {
             elifeGitMoveToBranch commit, 'approved'
+            node('containers-jenkins-plugin') {
+                def image = new DockerImage(steps, "xpub/xpub-elife", commit)
+                image.pull()
+                image.tag('approved').push()
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,10 +15,15 @@ elifePipeline {
 
     elifeMainlineOnly {
         stage 'Deploy on end2end', {
-            lock('elife-xpub--end2end') {
-                builderDeployRevision 'elife-xpub--end2end', commit
-                builderSmokeTests 'elife-xpub--end2end', '/srv/elife-xpub'
-            }
+            elifeSpectrum(
+                deploy: [
+                    stackname: 'elife-xpub--end2end',
+                    revision: commit,
+                    folder: '/srv/elife-xpub',
+                    concurrency: 'blue-green'
+                ],
+                marker: 'xpub'
+            )
         }
 
         stage 'Deploy on staging', {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,6 @@ elifePipeline {
                     stackname: 'elife-xpub--end2end',
                     revision: commit,
                     folder: '/srv/elife-xpub',
-                    concurrency: 'blue-green',
                     rollbackStep: {
                         builderDeployRevision 'elife-xpub--end2end', 'approved'
                         builderSmokeTests 'elife-xpub--end2end', '/srv/elife-xpub'


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/648

Rather than just deploying to `elife-xpub--end2end`; deploy, run smoke tests still and end2end tests after that.

~Does not implement rollback at the moment, would need to maintain an `approved`
image tag for that.~