### PR TITLE
Remove unnecessary approved image tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,11 +38,6 @@ elifePipeline {
 
         stage 'Approval', {
             elifeGitMoveToBranch commit, 'approved'
-            node('containers-jenkins-plugin') {
-                def image = new DockerImage(steps, "xpub/xpub-elife", commit)
-                image.pull()
-                image.tag('approved').push()
-            }
         }
     }
 }


### PR DESCRIPTION
Rollbacks are performed by using the `approved` branch of `elife-xpub-deployment`, which contains a `.env` file pointing to a particular `xpub:xpub-elife:$sha` Docker image tag. Therefore we don't need a `xpub:xpub-elife:approved` tag too, if that makes sense.