### PR TITLE
Introduce lock on elife-xpub--prod

### DIFF
--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -6,8 +6,10 @@ elifePipeline {
     }
 
     stage 'Deploy on prod', {
-        elifeGitMoveToBranch commit, 'master'
-        builderDeployRevision 'elife-xpub--prod', commit
-        builderSmokeTests 'elife-xpub--prod', '/srv/elife-xpub'
+        lock('elife-xpub--prod') {
+            elifeGitMoveToBranch commit, 'master'
+            builderDeployRevision 'elife-xpub--prod', commit
+            builderSmokeTests 'elife-xpub--prod', '/srv/elife-xpub'
+        }
     }
 }


### PR DESCRIPTION
Prevent accidental concurrent deployments and allows for infrastructure updates to lock the stack before being executed