### PR TITLE
Blue-green deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,10 +20,7 @@ elifePipeline {
                     stackname: 'elife-xpub--end2end',
                     revision: commit,
                     folder: '/srv/elife-xpub',
-                    rollbackStep: {
-                        builderDeployRevision 'elife-xpub--end2end', 'approved'
-                        builderSmokeTests 'elife-xpub--end2end', '/srv/elife-xpub'
-                    }
+                    concurrency: 'blue-green',
                 ],
                 marker: 'xpub'
             )
@@ -31,7 +28,7 @@ elifePipeline {
 
         stage 'Deploy on staging', {
             lock('elife-xpub--staging') {
-                builderDeployRevision 'elife-xpub--staging', commit
+                builderDeployRevision 'elife-xpub--staging', commit, 'blue-green'
                 builderSmokeTests 'elife-xpub--staging', '/srv/elife-xpub'
             }
         }

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -8,7 +8,7 @@ elifePipeline {
     stage 'Deploy on prod', {
         lock('elife-xpub--prod') {
             elifeGitMoveToBranch commit, 'master'
-            builderDeployRevision 'elife-xpub--prod', commit
+            builderDeployRevision 'elife-xpub--prod', commit, 'blue-green'
             builderSmokeTests 'elife-xpub--prod', '/srv/elife-xpub'
         }
     }


### PR DESCRIPTION
The default concurrency for deployment on multiple nodes is `serial`: one at a time.

For 2 nodes, `blue-green` is identical, but detaches every node from the load balancer before deploying to it; so in case of any failure the node stays detached and deploy stop; requests are not served by a node being deployed to, which may be doing maintenance operations.

If there were e.g. 6 nodes, `blue-green` would deploy first to 3 of them
and then to the other 3.