### PR TITLE
Use Jenkins-built Docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,9 +9,13 @@ elifePipeline {
         node('containers-jenkins-plugin') {
             checkout scm
             withCommitStatus({
-                sh 'docker-compose up -d'
-                sh 'docker wait xpub_bootstrap_1'
-                sh 'curl --verbose --fail localhost:3000'
+                try {
+                    sh 'docker-compose up -d'
+                    sh 'docker wait xpub_bootstrap_1'
+                    sh 'curl --verbose --fail localhost:3000'
+                } finally {
+                    sh 'docker-compose down -v'
+                }
             }, 'ci/smoke-tests', commit)
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,11 +5,13 @@ elifePipeline {
         commit = elifeGitRevision()
     }
 
-    node('containers-jenkins-plugin') {
-        checkout scm
-        sh 'docker-compose up -d'
-        sh 'docker wait xpub_bootstrap_1'
-        sh 'curl --verbose --fail localhost:3000'
+    stage 'Smoke tests', {
+        node('containers-jenkins-plugin') {
+            checkout scm
+            sh 'docker-compose up -d'
+            sh 'docker wait xpub_bootstrap_1'
+            sh 'curl --verbose --fail localhost:3000'
+        }
     }
 
     elifeMainlineOnly {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,13 @@ elifePipeline {
         commit = elifeGitRevision()
     }
 
+    node('containers-jenkins-plugin') {
+        checkout scm
+        sh 'docker-compose up -d'
+        sh 'docker wait xpub_bootstrap_1'
+        sh 'curl --verbose --fail localhost:3000'
+    }
+
     elifeMainlineOnly {
         stage 'Deploy on end2end', {
             def elifeXpubCommit = sh(script: "/bin/bash -c 'source .env && echo \$XPUB_VERSION'", returnStdout: true).trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,11 @@ elifePipeline {
     stage 'Smoke tests', {
         node('containers-jenkins-plugin') {
             checkout scm
-            sh 'docker-compose up -d'
-            sh 'docker wait xpub_bootstrap_1'
-            sh 'curl --verbose --fail localhost:3000'
+            withCommitStatus({
+                sh 'docker-compose up -d'
+                sh 'docker wait xpub_bootstrap_1'
+                sh 'curl --verbose --fail localhost:3000'
+            }, 'ci/smoke-tests', commit)
         }
     }
 

--- a/Jenkinsfile.update-xpub
+++ b/Jenkinsfile.update-xpub
@@ -1,12 +1,9 @@
 elifeUpdatePipeline(
     { commit ->
-        // sh 'env' 
-        // DOCKER_TRIGGER_REPO_NAME=xpub
-        node('containers-jenkins-plugin') {
-            commit = dockerReadLabel('xpub/xpub-elife:latest', 'COMMIT_SHA')
+        if (params.commit) {
+            sh "sed -i -e 's/XPUB_VERSION=.*/XPUB_VERSION=${params.commit}/' .env"
+            sh "git add .env"
         }
-        sh "sed -i -e 's/XPUB_VERSION=.*/XPUB_VERSION=${commit}/' .env"
-        sh "git add .env"
     },
     {
         def xpubCommit = sh(script: "cat .env | grep XPUB_VERSION", returnStdout: true)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An eLife specific implementation of the [xPub][1] submission and peer-review sys
 
 This is a collaboration between eLife and the Collaborative Knowledge Foundation (Coko), [more information in our press release][3].
 
-[1]: https://gitlab.coko.foundation/xpub/xpub-elife
+[1]: https://github.com/elifesciences/elife-xpub
 [2]: https://gitlab.coko.foundation/pubsweet/pubsweet-server
 [3]: https://elifesciences.org/for-the-press/67d013c4/elife-and-collaborative-knowledge-foundation-partner-to-deliver-open-source-submission-and-peer-review-platform
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     app:
-        image: xpub/xpub-elife:${XPUB_VERSION}
+        image: elifesciences/elife-xpub:${XPUB_VERSION}
         command: >
             /bin/bash -c "
                 until echo > /dev/tcp/${PGHOST}/5432; do sleep 1; done


### PR DESCRIPTION
See https://github.com/elifesciences/elife-xpub/pull/1130

Shaves 8 minutes of the time from merging to the change being available to the user, and continues the retirement of Gitlab CI.

https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-xpub-deployment-update-xpub/ will now be triggered esclusively by https://alfred.elifesciences.org/job/test-elife-xpub-source-repository/ which passed the `commit`. The Docker Hub hook will be ignored, since it doesn't pass the parameter, and can eventually be removed.

https://hub.docker.com/r/elifesciences/elife-xpub/tags/ and https://hub.docker.com/r/xpub/xpub-elife/tags/ have both the various image tags that have been used here such as the current `93a22041fc78eb727d42b74500b9b484c36df03d`.