### PR TITLE
Add healthcheck to sciencebeam container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,11 @@ services:
         networks:
         - default
         - sciencebeam-internal
+        healthcheck:
+            test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/8075"]
+            interval: 10s
+            timeout: 10s
+            retries: 5
         restart: always
         depends_on:
         - grobid


### PR DESCRIPTION
This enables the formula to wait for all containers to be up and healthy before attempting to warm up sciencebeam or run any smoke test

```
5711f2bd4654        elifesciences/elife-xpub:eb62007acfced2a188bfa72466316d66ce5b20bf   "/bin/bash -c '\n    …"   15 seconds ago      Up 12 seconds             0.0.0.0:3000->3000/tcp   xpub_app_1
8ff76045fad7        elifesciences/sciencebeam:0.0.1                                     "./server.sh ' --hos…"    16 seconds ago      Up 11 seconds (healthy)   0.0.0.0:8075->8075/tcp   xpub_sciencebeam_1
40adb21e86c2        postgres:10                                                         "docker-entrypoint.s…"    17 seconds ago      Up 14 seconds             0.0.0.0:5432->5432/tcp   xpub_postgres_1
23b00dbb9bbc        lfoppiano/grobid:0.5.1                                              "/tini -- ./grobid-s…"    17 seconds ago      Up 15 seconds (healthy)                            xpub_grobid_1
```